### PR TITLE
feat(cmd): introduce tsv subcommand

### DIFF
--- a/cellfree/cmd/cellfree.py
+++ b/cellfree/cmd/cellfree.py
@@ -1,6 +1,6 @@
 import click
 
-from cellfree.cmd import prepare, end_motif, all
+from cellfree.cmd import prepare, end_motif, tsv, all
 
 
 @click.group()
@@ -17,4 +17,5 @@ def main(verbose, conf):
 
 main.add_command(prepare.prepare)
 main.add_command(end_motif.end_motif)
+main.add_command(tsv.tsv)
 main.add_command(all.all)

--- a/cellfree/cmd/tsv.py
+++ b/cellfree/cmd/tsv.py
@@ -1,0 +1,15 @@
+import click
+
+
+@click.command()
+@click.argument("tagged-bamfile")
+@click.option("--end-motif", is_flag=True, show_default=True, default=False,
+              help="Insert result to the end-motif column in the tsv")
+@click.option("--frag", is_flag=True, show_default=True, default=False,
+              help="Insert result to the frag column in the tsv")
+def tsv(tagged_bamfile, end_motif, frag):
+    print(f"Tagged Bamfile: {tagged_bamfile}")
+    if end_motif:
+        print(f"Enabled:        end_motif")
+    if frag:
+        print(f"Enabled:        frag")


### PR DESCRIPTION
How the usage looks like:

```
(cellfree-io3neF18-py3.8) [^_^]─[~/work-my-projects/cellfree-working/cellfree] tai271828@syakaro: 220410-11:39:31 14 file 252Kb
$ cellfree tsv foo-bar --end-motif --frag
Tagged Bamfile: foo-bar
Enabled:        end_motif
Enabled:        frag
(cellfree-io3neF18-py3.8) [^_^]─[~/work-my-projects/cellfree-working/cellfree] tai271828@syakaro: 220410-11:39:41 14 file 252Kb
$ cellfree tsv foo-bar --end-motif
Tagged Bamfile: foo-bar
Enabled:        end_motif
(cellfree-io3neF18-py3.8) [^_^]─[~/work-my-projects/cellfree-working/cellfree] tai271828@syakaro: 220410-11:39:43 14 file 252Kb
$ cellfree tsv foo-bar
Tagged Bamfile: foo-bar
```